### PR TITLE
Add Furriq to Cat Care & Treatment

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,7 @@ Goal of this project is simply to gather verified animal care content written by
 - [Cat Health Center - FETCH by WebMD](https://www.webmd.com/pets/cats/default.htm) - Collection of information resources related to cat health.
 - [Catster](https://www.catster.com/) - Information about cat health, behaviour and products. A popular cat blog called "Conscious Cat" is [now part of Catster](https://www.catster.com/lifestyle/conscious-cat-is-now-a-part-of-catster/).
 - [Common Cat Diseases - American Society for the Prevention of Cruelty to Animals (ASPCA)](https://www.aspca.org/pet-care/cat-care/common-cat-diseases) - Information about diseases and other medical inflictions that frequently impact cats.
+- [Furriq](https://www.furriq.com/breeds) - Free cat breed reference with 61 breed profiles, 121 side-by-side breed comparisons and a photo-based breed identifier that checks 40+ visual markers. No sign-up required and uploaded photos are not stored.
 
 ### Cat Behaviour & Training
 


### PR DESCRIPTION
## What

Adds [Furriq](https://www.furriq.com/breeds) to the **Cat Care & Treatment** section.

## Why it fits this list

Furriq is a free cat breed reference:

- 61 breed profiles covering appearance, temperament, grooming and health notes
- 75 side-by-side breed comparisons (e.g. [Maine Coon vs Ragdoll](https://www.furriq.com/compare/maine-coon-vs-ragdoll)) for owners choosing between similar breeds
- A photo-based breed identifier that checks 40+ visual markers, free to use with no sign-up, and uploaded photos are not stored

It is free, requires no account and has no paywall, so it sits well alongside the other expert care resources in this section. The entry is placed at the end of the section to preserve alphabetical ordering, and the description follows the contributing guidelines (factual, no marketing language).
